### PR TITLE
LURKABLE has been renamed to PUBLIC (#1119)

### DIFF
--- a/docs/resources/Guild.md
+++ b/docs/resources/Guild.md
@@ -100,7 +100,7 @@ Guilds in Discord represent an isolated collection of users and channels, and ar
 | VANITY_URL    | guild has access to set a vanity URL                                            |
 | VERIFIED      | guild is verified                                                               |
 | PARTNERED     | guild is partnered                                                              |
-| LURKABLE      | guild is lurkable                                                               |
+| PUBLIC        | guild is public                                                               |
 | COMMERCE      | guild has access to use commerce features (i.e. create store channels)          |
 | NEWS          | guild has access to create news channels                                        |
 | DISCOVERABLE  | guild is able to be discovered in the directory                                 |


### PR DESCRIPTION
The `LURKABLE` feature has been renamed to `PUBLIC`